### PR TITLE
Fix for Forge 1841+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ group= "at.feldim2425.moreoverlays" // http://maven.apache.org/guides/mini/guide
 archivesBaseName = "moreoverlays"
 
 minecraft {
-    version = "1.9-12.16.0.1832-1.9"
+    version = "1.9-12.16.0.1849-1.9"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,3 @@
 moov.version=0.4
 
-jei.version=3.2.5.179
+jei.version=3.2.6.180

--- a/src/main/java/at/feldim2425/moreoverlays/KeyBindings.java
+++ b/src/main/java/at/feldim2425/moreoverlays/KeyBindings.java
@@ -21,10 +21,6 @@ public class KeyBindings {
     public static KeyBinding invSearch = new KeyBinding("key." + MoreOverlays.MOD_ID + ".invsearch.desc", KeyConflictContext.GUI, Keyboard.KEY_Z, "key." + MoreOverlays.MOD_ID + ".category");
 
     public static void init() {
-        lightOverlay.setAllowsKeyModifiers();
-        chunkBounds.setAllowsKeyModifiers();
-        invSearch.setAllowsKeyModifiers();
-
         ClientRegistry.registerKeyBinding(lightOverlay);
         ClientRegistry.registerKeyBinding(chunkBounds);
         ClientRegistry.registerKeyBinding(invSearch);

--- a/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
+++ b/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = MoreOverlays.MOD_ID, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "after:JEI@[2.28.12.180,);")
+@Mod(modid = MoreOverlays.MOD_ID, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "required-after:Forge@[12.16.0.1841,);after:JEI@[2.28.12.180,);")
 public class MoreOverlays {
 
     public static final String MOD_ID = "moreoverlays";


### PR DESCRIPTION
This fixes incompatibilities with Forge 1841+ (and updates dependencies), which produced the following crash:
`Caused by: java.lang.NoSuchMethodError: net.minecraft.client.settings.KeyBinding.setAllowsKeyModifiers()V
    at at.feldim2425.moreoverlays.KeyBindings.init(KeyBindings.java:24)
    at at.feldim2425.moreoverlays.Proxy.preInit(Proxy.java:15)
    at at.feldim2425.moreoverlays.MoreOverlays.preInit(MoreOverlays.java:26)`
