### PR TITLE
Improve startup time and reduce log spam by using new JEI API to get filtered items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 # other
 eclipse
 run
+classes

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     //compile "some.group:artifact:version"
       
 	deobfCompile "mezz.jei:jei_1.10.2:${config.jei.version}"
+	deobfCompile "slimeknights.mantle:Mantle:1.10.2-${config.mantle.version}"
 
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,4 @@
 moov.version=1.7
 
 jei.version=3.9.0.244
+mantle.version=1.0.0.jenkins170

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
 moov.version=1.7
 
-jei.version=3.9.0.244
+jei.version=3.9.6.258
 mantle.version=1.0.0.jenkins170

--- a/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
+++ b/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = MoreOverlays.MOD_ID, updateJSON = MoreOverlays.UPDATE_JSON, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "required-after:Forge@[12.18.1.2075,);after:JEI@[3.9.0.244,);", guiFactory = "at.feldim2425.moreoverlays.config.GuiFactory")
+@Mod(modid = MoreOverlays.MOD_ID, updateJSON = MoreOverlays.UPDATE_JSON, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "required-after:Forge@[12.18.1.2075,);after:JEI@[3.9.6.258,);", guiFactory = "at.feldim2425.moreoverlays.config.GuiFactory")
 public class MoreOverlays {
 
     public static final String MOD_ID = "moreoverlays";

--- a/src/main/java/at/feldim2425/moreoverlays/itemsearch/GuiHandler.java
+++ b/src/main/java/at/feldim2425/moreoverlays/itemsearch/GuiHandler.java
@@ -42,7 +42,6 @@ public class GuiHandler {
 
     private static boolean enabled = false;
 
-    private static List<ItemStack> itemCache = null;
     private static String lastFilterText = "";
     private static boolean emptyFilter = true;
     private static List<String> tooltip = new ArrayList<>();
@@ -201,7 +200,7 @@ public class GuiHandler {
     private boolean isSearchedItem(ItemStack stack) {
         if(emptyFilter) return true;
         else if(stack==null) return false;
-        for (ItemStack stack1 : itemCache) {
+        for (ItemStack stack1 : JeiModule.overlay.getFilteredStacks()) {
             if (stack1.isItemEqual(stack) || (stack1.getItem() == stack.getItem() && stack1.getItem().isDamageable()))
                 return true;
         }
@@ -214,11 +213,6 @@ public class GuiHandler {
             return;
         if (enabled && !JeiModule.overlay.getFilterText().equals(lastFilterText)) {
             lastFilterText = JeiModule.overlay.getFilterText();
-            if (itemCache != null)
-                itemCache.clear();
-            else
-                itemCache = new ArrayList<>();
-            JeiModule.filter.getItemList().forEach((itemElement) -> itemCache.add(itemElement.getItemStack()));
             emptyFilter = lastFilterText.replace(" ","").isEmpty();
         }
 
@@ -235,17 +229,10 @@ public class GuiHandler {
         enabled = !enabled;
         if (enabled) {
             lastFilterText = JeiModule.overlay.getFilterText();
-            if (itemCache != null)
-                itemCache.clear();
-            else
-                itemCache = new ArrayList<>();
-            JeiModule.filter.getItemList().forEach((itemElement) -> itemCache.add(itemElement.getItemStack()));
             emptyFilter = lastFilterText.replace(" ","").isEmpty();
             text = I18n.translateToLocal("gui." + MoreOverlays.MOD_ID + ".search.enabled");
         } else {
             lastFilterText = "";
-            if (itemCache != null)
-                itemCache.clear();
             text = I18n.translateToLocal("gui." + MoreOverlays.MOD_ID + ".search.disabled");
         }
         highlightTicks=TEXT_FADEOUT;

--- a/src/main/java/at/feldim2425/moreoverlays/itemsearch/JeiModule.java
+++ b/src/main/java/at/feldim2425/moreoverlays/itemsearch/JeiModule.java
@@ -1,22 +1,15 @@
 package at.feldim2425.moreoverlays.itemsearch;
 
-import mezz.jei.ItemFilter;
 import mezz.jei.api.*;
 import mezz.jei.input.IKeyable;
 
 import javax.annotation.Nonnull;
 
 @JEIPlugin
-public class JeiModule implements IModPlugin {
+public class JeiModule extends BlankModPlugin {
 
-    public static ItemFilter filter;
     public static IItemListOverlay overlay;
     public static IKeyable keyableOverlay;
-
-    @Override
-    public void register(@Nonnull IModRegistry registry) {
-        filter = new ItemFilter(registry.getItemRegistry());
-    }
 
     @Override
     public void onRuntimeAvailable(@Nonnull IJeiRuntime jeiRuntime) {


### PR DESCRIPTION
MoreOverlays is creating a new ItemFilter on startup, which takes a while and spams the log with lots of item errors (this is normal, but I want to avoid having it happen twice). On a big pack, the log said it was taking more than 4600 ms to start. After this PR it's 0 ms, so the ItemFilter was the only thing taking time.

I added a new thing to JEI's API so you can get the filtered item list, and used that in this PR instead of the new ItemFilter.

I also added Mantle to your gradle since it was required in order to build and test the project. It's on the same maven as JEI but the deobfCompile line is a bit different.
