### PR TITLE
Update to MC 1.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ group= "at.feldim2425.moreoverlays" // http://maven.apache.org/guides/mini/guide
 archivesBaseName = "moreoverlays"
 
 minecraft {
-    version = "14.21.0.2330"
+    version = "14.22.0.2452"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.
@@ -47,7 +47,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20170615"
+    mappings = "snapshot_20170916"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
@@ -62,7 +62,7 @@ dependencies {
     //compile "some.group:artifact:version:classifier"
     //compile "some.group:artifact:version"
       
-	deobfCompile "mezz.jei:jei_1.12:${config.jei.version}"
+	deobfCompile "mezz.jei:jei_1.12.1:${config.jei.version}"
 	deobfProvided "slimeknights.mantle:Mantle:1.11.2-${config.mantle.version}"
 
     // real examples

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-moov.version=1.12
+moov.version=1.12.1
 
-jei.version=4.6.0.61
+jei.version=4.7.7.+
 mantle.version=1.2.0.26

--- a/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
+++ b/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = MoreOverlays.MOD_ID, updateJSON = MoreOverlays.UPDATE_JSON, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "required-after:forge@[14.21.0.2330,);after:jei@[4.6.0.61,);", guiFactory = "at.feldim2425.moreoverlays.config.GuiFactory")
+@Mod(modid = MoreOverlays.MOD_ID, updateJSON = MoreOverlays.UPDATE_JSON, version = MoreOverlays.VERSION, name = MoreOverlays.NAME, clientSideOnly = true, dependencies = "required-after:forge@[14.22.0.2452,);after:jei@[4.7.7.+,);", guiFactory = "at.feldim2425.moreoverlays.config.GuiFactory")
 public class MoreOverlays {
 
     public static final String MOD_ID = "moreoverlays";

--- a/src/main/java/at/feldim2425/moreoverlays/config/GuiFactory.java
+++ b/src/main/java/at/feldim2425/moreoverlays/config/GuiFactory.java
@@ -23,17 +23,7 @@ public class GuiFactory implements IModGuiFactory {
     }
 
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass() {
-        return ModConfigGui.class;
-    }
-
-    @Override
     public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
-        return null;
-    }
-
-    @Override
-    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element) {
         return null;
     }
 }


### PR DESCRIPTION
I am relatively new to creating or updating forge mods, but I believe I made the minimum edits to get More Overlays working in Minecraft 1.12.1. I played with a locally compiled version with this patch for about 30 minutes on 1.12.1 today and did not experience any crashing or other issues.

Please note: I opened this pull request against your "master-1.12" branch, but it is against my "master-1.12.1" branch.  I am not certain how to perform a pull request that creates a new branch in your repository, but that was my preference based on your apparent branching strategy.

Regards,
Chris Tilden