### PR TITLE
Fix chunk borders not showing at Y<0

### DIFF
--- a/src/main/java/at/feldim2425/moreoverlays/chunkbounds/ChunkBoundsRenderer.java
+++ b/src/main/java/at/feldim2425/moreoverlays/chunkbounds/ChunkBoundsRenderer.java
@@ -28,8 +28,8 @@ public class ChunkBoundsRenderer {
 
 		int h = player.world.getHeight();
 		int h0 = (int) player.posY;
-		int h1 = Math.min(h, Math.max(h0 - 16, 0));
-		int h2 = Math.min(h, Math.max(h0 + 16, 0));
+		int h1 = Math.min(h, h0 - 16);
+		int h2 = Math.min(h, h0 + 16);
 
 		int x0 = player.chunkCoordX * 16;
 		int x1 = x0 + 16;


### PR DESCRIPTION
When some people using CubicChunks they willing to see a chunk boundaries below Y=0.