### PR TITLE
Added support for light level overlay for DrZharks Custom Mob Spawner…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,12 @@ tasks.withType(JavaCompile) {
     targetCompatibility = "1.8"
 }
 
-version = "1.14"
+version = "1.15"
 group = "at.feldim2425.moreoverlays" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "moreoverlays"
 
 minecraft {
-    version = "14.23.4.2739"
+    version = "1.12.2-14.23.5.2808"
     runDir = "run"
 
     // the mappings can be changed at any time, and must be in the following format.

--- a/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayHandler.java
+++ b/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayHandler.java
@@ -25,14 +25,14 @@ public class LightOverlayHandler {
 	public static void toggleMode() {
 		enabled = !enabled;
 		if (!enabled) {
-			LightOverlayRenderer.clearCache();
+			LightOverlayRenderer.instance().clearCache();
 		}
 	}
 
 	@SubscribeEvent
 	public void renderWorldLastEvent(RenderWorldLastEvent event) {
 		if (enabled) {
-			LightOverlayRenderer.renderOverlays();
+			LightOverlayRenderer.instance().renderOverlays();
 		}
 	}
 
@@ -40,7 +40,7 @@ public class LightOverlayHandler {
 	public void onClientTick(TickEvent.ClientTickEvent event) {
 		if (Minecraft.getMinecraft().world != null && enabled && event.phase == TickEvent.Phase.END &&
 				(Minecraft.getMinecraft().currentScreen == null || !Minecraft.getMinecraft().currentScreen.doesGuiPauseGame())) {
-			LightOverlayRenderer.refreshCache();
+			LightOverlayRenderer.instance().refreshCache();
 		}
 
 	}

--- a/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererVanilla.java
+++ b/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererVanilla.java
@@ -1,0 +1,18 @@
+package at.feldim2425.moreoverlays.lightoverlay;
+
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+public class LightOverlayRendererVanilla extends LightOverlayRenderer {
+
+	@Override
+	protected boolean checkIfBiomeSpawnlistIsEmpty(World world, int x, int y, int z) {
+		BlockPos pos1 = new BlockPos(x, y, z);
+		Biome biome = world.getBiome(pos1);
+
+		return (biome.getSpawningChance() <= 0 || biome.getSpawnableList(EnumCreatureType.MONSTER).isEmpty());
+	}
+
+}

--- a/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererZharkCustomSpawner.java
+++ b/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererZharkCustomSpawner.java
@@ -1,0 +1,29 @@
+package at.feldim2425.moreoverlays.lightoverlay;
+
+import java.util.List;
+
+import drzhark.customspawner.CustomSpawner;
+import drzhark.customspawner.environment.EnvironmentSettings;
+import drzhark.customspawner.utils.CMSUtils;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.Biome.SpawnListEntry;
+
+public class LightOverlayRendererZharkCustomSpawner extends LightOverlayRenderer {
+
+	protected boolean checkIfBiomeSpawnlistIsEmpty(World world, int x, int y, int z) {
+		BlockPos pos = new BlockPos(x, y, z);
+		Biome biome = world.getBiome(pos);
+		if(biome.getSpawningChance() <= 0)
+			return true;
+		
+		EnvironmentSettings environment = CMSUtils.getEnvironment(world);
+		if (environment == null) {
+		  System.out.println("return");
+		}
+		List<SpawnListEntry> possibleSpawns = CustomSpawner.instance().getPossibleCustomCreatures(world, environment.entitySpawnTypes.get("MONSTER"), x, y, z);
+
+		return possibleSpawns.isEmpty();
+	}
+}

--- a/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererZharkCustomSpawner.java
+++ b/src/main/java/at/feldim2425/moreoverlays/lightoverlay/LightOverlayRendererZharkCustomSpawner.java
@@ -20,7 +20,7 @@ public class LightOverlayRendererZharkCustomSpawner extends LightOverlayRenderer
 		
 		EnvironmentSettings environment = CMSUtils.getEnvironment(world);
 		if (environment == null) {
-		  System.out.println("return");
+		  return true;
 		}
 		List<SpawnListEntry> possibleSpawns = CustomSpawner.instance().getPossibleCustomCreatures(world, environment.entitySpawnTypes.get("MONSTER"), x, y, z);
 


### PR DESCRIPTION
Light level overlay does not work with MoCreatures and Custom Mob Spawner by DrZhark installed.
I fixed this here to check for Custom Mob Spawner on the classpath and adding the respective light level handler if it is present. Tested on Forge 2808 (MC 1.12.2) with Custom Mob Spawner 3.11.4.