### PR TITLE
Config fixes v1.14

### DIFF
--- a/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
+++ b/src/main/java/at/feldim2425/moreoverlays/MoreOverlays.java
@@ -43,6 +43,6 @@ public class MoreOverlays {
 	}
 
 	public Screen openSettings(Minecraft mc, Screen modlist){
-		return new ConfigScreen(Config.config_client, MOD_ID);
+		return new ConfigScreen(modlist, Config.config_client, MOD_ID);
 	}
 }

--- a/src/main/java/at/feldim2425/moreoverlays/gui/ConfigScreen.java
+++ b/src/main/java/at/feldim2425/moreoverlays/gui/ConfigScreen.java
@@ -41,8 +41,16 @@ public class ConfigScreen extends Screen {
 
     @Override
     protected void init() {
-        this.optionList = new ConfigOptionList(this.minecraft, this.modId, this);
-
+        if (this.optionList == null) {
+    		this.optionList = new ConfigOptionList(this.minecraft, this.modId, this);
+    		
+    		if(pathCache.isEmpty()){
+                this.optionList.setConfiguration(configSpec);
+            }
+            else {
+                this.optionList.setConfiguration(configSpec, this.pathCache);
+            }            
+    	}
         final int buttonY = this.height - 32 + (32-20)/2;
 
         this.btnReset = new Button(this.width-40, buttonY, 20, 20, ConfigOptionList.RESET_CHAR,
@@ -61,13 +69,7 @@ public class ConfigScreen extends Screen {
         this.btnUndo.active = false;
         this.btnSave.active = false;
 
-
-        if(pathCache.isEmpty()){
-            this.optionList.setConfiguration(configSpec);
-        }
-        else {
-            this.optionList.setConfiguration(configSpec, this.pathCache);
-        }
+        this.optionList.updateGui();
     }
     
     private void back() {    	    	

--- a/src/main/java/at/feldim2425/moreoverlays/gui/ConfigScreen.java
+++ b/src/main/java/at/feldim2425/moreoverlays/gui/ConfigScreen.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import at.feldim2425.moreoverlays.MoreOverlays;
 import at.feldim2425.moreoverlays.gui.config.ConfigOptionList;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.client.resources.I18n;
@@ -26,11 +27,13 @@ public class ConfigScreen extends Screen {
     private String txtUndo = "";
     private String txtReset = "";
     
+    private Screen modListScreen;
 
-    public ConfigScreen(ForgeConfigSpec spec, String modId) {
+    public ConfigScreen(Screen modListScreen, ForgeConfigSpec spec, String modId) {
         super(new TranslationTextComponent("gui.config."+modId+".tile"));
+        this.modListScreen = modListScreen;
         this.configSpec = spec;
-        this.modId = modId;
+        this.modId = modId;        
 
         this.txtReset = I18n.format("gui.config." + MoreOverlays.MOD_ID + ".reset_config");
         this.txtUndo = I18n.format("gui.config." + MoreOverlays.MOD_ID + ".undo");
@@ -67,7 +70,16 @@ public class ConfigScreen extends Screen {
         }
     }
     
-    @Override
+    private void back() {    	    	
+        if(!this.optionList.getCurrentPath().isEmpty()){
+            this.optionList.pop();           
+        }
+        else {
+        	Minecraft.getInstance().displayGuiScreen(modListScreen);
+        }
+	}
+
+	@Override
     public void render(int mouseX, int mouseY, float partialTick) {
         this.renderBackground();
         this.optionList.render(mouseX, mouseY, partialTick);
@@ -117,9 +129,9 @@ public class ConfigScreen extends Screen {
 
     @Override
     public boolean keyPressed(int key, int p_keyPressed_2_, int p_keyPressed_3_) {
-        if(key == 256 && !this.optionList.getCurrentPath().isEmpty()){
-            this.optionList.pop();
-            return true;
+        if (key == 256) {
+        	this.back();
+        	return true;
         }
         else {
             return super.keyPressed(key, p_keyPressed_2_, p_keyPressed_3_);

--- a/src/main/java/at/feldim2425/moreoverlays/gui/config/ConfigOptionList.java
+++ b/src/main/java/at/feldim2425/moreoverlays/gui/config/ConfigOptionList.java
@@ -65,6 +65,11 @@ public class ConfigOptionList extends AbstractOptionList<ConfigOptionList.Option
     public int getRowWidth() {
         return super.getRowWidth() + 64;
     }
+    
+    public void updateGui() {
+    	this.updateSize(this.parent.width, this.parent.height, 43, this.parent.height - 32);
+    }
+
 
     @Override
     protected void renderDecorations(int p_renderDecorations_1_, int p_renderDecorations_2_) {

--- a/src/main/java/at/feldim2425/moreoverlays/gui/config/ConfigOptionList.java
+++ b/src/main/java/at/feldim2425/moreoverlays/gui/config/ConfigOptionList.java
@@ -186,6 +186,7 @@ public class ConfigOptionList extends AbstractOptionList<ConfigOptionList.Option
                 this.addEntry(new OptionGeneric<>(this, (ForgeConfigSpec.ConfigValue<?>)cEntry.getValue(), (ForgeConfigSpec.ValueSpec)rootConfig.getSpec().get(fullPath)));
             }
         }
+        this.setFocused(null);
     }
 
     public List<String> getCurrentPath() {


### PR DESCRIPTION
Hi, 

I've been using your mod config UIs for my own mods, and fixed a few issues while I was at it. 

1) "back" from the top level now takes you back to the mods list, consistent with previous versions of forge, (i.e. previously went all the way back to the main menu)
2) you can resize the window without losing the config changes (issue #70).
3) there was a crash when using keyboard navigation due to stale button focus.

Thanks for sharing, it's been really helpful for reintroducing a config UI within 1.14.